### PR TITLE
Fix configuration reset after upgrade 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Joomla! is a free and open-source content management system (CMS) for publishing web content. Over the years Joomla! has won several awards. It is built on a model–view–controller web application framework that can be used independently of the CMS that allows you to build powerful online applications.
 
 
-**Shipped version:** 4.1.4~ynh1
+**Shipped version:** 4.1.4~ynh2
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Joomla! is a free and open-source content management system (CMS) for publishing web content. Over the years Joomla! has won several awards. It is built on a model–view–controller web application framework that can be used independently of the CMS that allows you to build powerful online applications.
 
 
-**Version incluse :** 4.1.4~ynh1
+**Version incluse :** 4.1.4~ynh2
 
 ## Captures d'écran
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "A content management system."
     },
-    "version": "4.1.4~ynh1",
+    "version": "4.1.4~ynh2",
     "url": "https://www.joomla.org",
     "upstream": {
         "license": "GPL-2.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,6 +9,45 @@ YNH_PHP_VERSION="8.0"
 
 pkg_dependencies="php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-posix php${YNH_PHP_VERSION}-bz2 php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-memcache php${YNH_PHP_VERSION}-memcached php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-sockets php${YNH_PHP_VERSION}-mcrypt php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-fileinfo php${YNH_PHP_VERSION}-mbstring"
 
+# from nextcloud common script 
+
+# Check available space before creating a temp directory.
+#
+# usage: ynh_smart_mktemp --min_size="Min size"
+#
+# | arg: -s, --min_size= - Minimal size needed for the temporary directory, in Mb
+ynh_smart_mktemp () {
+        # Declare an array to define the options of this helper.
+        declare -Ar args_array=( [s]=min_size= )
+        local min_size
+        # Manage arguments with getopts
+        ynh_handle_getopts_args "$@"
+
+        min_size="${min_size:-300}"
+        # Transform the minimum size from megabytes to kilobytes
+        min_size=$(( $min_size * 1024 ))
+
+        # Check if there's enough free space in a directory
+        is_there_enough_space () {
+                local free_space=$(df --output=avail "$1" | sed 1d)
+                test $free_space -ge $min_size
+        }
+
+        if is_there_enough_space /tmp; then
+                local tmpdir=/tmp
+        elif is_there_enough_space /var; then
+                local tmpdir=/var
+        elif is_there_enough_space /; then
+                local tmpdir=/
+        elif is_there_enough_space /home; then
+                local tmpdir=/home
+        else
+                ynh_die "Insufficient free space to continue..."
+        fi
+
+        echo "$(mktemp --directory --tmpdir="$tmpdir")"
+}
+ 
 #=================================================
 # PERSONAL HELPERS
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -48,6 +48,17 @@ ynh_clean_setup () {
 ynh_abort_if_errors
 
 #=================================================
+# BACKUP CONFIGURATION FILE
+#=================================================
+ynh_script_progression --message="Backing up configuration file..."
+
+    # Create a temporary directory
+    tmpdir="$(ynh_smart_mktemp min_size=3)"
+    
+    # Backup the config file in the temp dir
+    cp -a "$final_path/configuration.php" "$tmpdir/configuration.php"
+
+#=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -116,11 +127,15 @@ ynh_add_fpm_config
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
-# UPDATE A CONFIG FILE
+# RESTORE A CONFIG FILE
 #=================================================
-ynh_script_progression --message="Updating a configuration file..."
+ynh_script_progression --message="Restoring configuration file..."
 
-ynh_add_config --template="../conf/configuration.php" --destination="$final_path/configuration.php"
+#ynh_add_config --template="../conf/configuration.php" --destination="$final_path/configuration.php"
+
+    # Restore config file
+    mv -f "$tmpdir/configuration.php" "$final_path/configuration.php"
+    ynh_secure_remove --file="$tmpdir"
 
 chmod 400 "$final_path/configuration.php"
 chown $app:$app "$final_path/configuration.php"


### PR DESCRIPTION
# Problem : 
when upgrading joomla, all configurations are reset because the old configuration file is deleted and replaced by a new clean one with default
# Soltuion : 
backup config file in a temporary folder before running the update then restore it after the update 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
